### PR TITLE
chore: update Podman Desktop API version and update types to use new vm type API

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
         "macadam.factory.machine.image-path": {
           "type": "string",
           "format": "file",
-          "scope": "ContainerProviderConnectionFactory",
+          "scope": "VmProviderConnectionFactory",
           "default": "",
           "description": "Image Path"
         },
         "macadam.factory.machine.ssh-identity-path": {
           "type": "string",
           "format": "file",
-          "scope": "ContainerProviderConnectionFactory",
+          "scope": "VmProviderConnectionFactory",
           "default": "",
           "description": "Ssh Identity Path"
         },
@@ -34,7 +34,7 @@
           "default": "HOST_HALF_CPU_CORES",
           "minimum": 1,
           "maximum": "HOST_TOTAL_CPU",
-          "scope": "ContainerProviderConnectionFactory",
+          "scope": "VmProviderConnectionFactory",
           "description": "CPU(s)"
         },
         "macadam.factory.machine.memory": {
@@ -43,7 +43,7 @@
           "minimum": 1000000000,
           "default": 4000000000,
           "maximum": "HOST_TOTAL_MEMORY",
-          "scope": "ContainerProviderConnectionFactory",
+          "scope": "VmProviderConnectionFactory",
           "step": 500000000,
           "description": "Memory"
         },
@@ -54,7 +54,7 @@
           "minimum": 10000000000,
           "maximum": "HOST_TOTAL_DISKSIZE",
           "step": 500000000,
-          "scope": "ContainerProviderConnectionFactory",
+          "scope": "VmProviderConnectionFactory",
           "description": "Disk size"
         },
         "macadam.factory.machine.win.provider": {
@@ -64,7 +64,7 @@
             "wsl",
             "hyperv"
           ],
-          "scope": "ContainerProviderConnectionFactory",
+          "scope": "VmProviderConnectionFactory",
           "description": "Provider Type",
           "when": "macadam.wslHypervEnabled"
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -159,9 +159,9 @@ async function getJSONMachineList(): Promise<MachineJSONListOutput> {
 
 export async function getJSONMachineListByProvider(vmProvider?: string): Promise<MachineJSONListOutput> {
   const { stdout, stderr } = await execMacadam(['list'], vmProvider);
-  return { 
-    list: stdout ? JSON.parse(stdout) as MachineJSON[] : [], 
-    error: stderr ,
+  return {
+    list: stdout ? (JSON.parse(stdout) as MachineJSON[]) : [],
+    error: stderr,
   };
 }
 


### PR DESCRIPTION
This PR updates existing code to use the newly added VM types in the Podman Desktop API

Closes https://github.com/redhat-developer/podman-desktop-rhel-ext/issues/7

Needs to be rebase after https://github.com/redhat-developer/podman-desktop-rhel-ext/pull/37 is merged