### PR TITLE
chore: update Podman Desktop API version

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
   },
   "scripts": {
     "build": "vite build",
-    "test": "vitest run --coverage",
-    "test:watch": "vitest watch --coverage",
+    "test": "vitest run --coverage --passWithNoTests",
+    "test:watch": "vitest watch --coverage --passWithNoTests",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "format:fix": "prettier --write \"src/**/*.ts\"",
     "lint:check": "eslint .",

--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
   },
   "scripts": {
     "build": "vite build",
-    "test": "vitest run --coverage --passWithNoTests",
-    "test:watch": "vitest watch --coverage --passWithNoTests",
+    "test": "vitest run --coverage",
+    "test:watch": "vitest watch --coverage",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "format:fix": "prettier --write \"src/**/*.ts\"",
     "lint:check": "eslint .",
@@ -83,7 +83,7 @@
     "watch": "vite build -w"
   },
   "dependencies": {
-    "@podman-desktop/api": "^1.17.2",
+    "@podman-desktop/api": "1.18.0-202504081837-802a404223c",
     "compare-versions": "^6.1.1",
     "semver": "^7.7.1",
     "ssh2": "^1.16.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2275,6 +2275,9 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -4287,6 +4290,8 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  html-escaper@2.0.2: {}
+
   http-cache-semantics@4.1.1: {}
 
   http-proxy-agent@7.0.2:
@@ -5055,6 +5060,8 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
+
+  std-env@3.9.0: {}
 
   std-env@3.9.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@podman-desktop/api':
-        specifier: ^1.17.2
-        version: 1.17.2
+        specifier: 1.18.0-202504081837-802a404223c
+        version: 1.18.0-202504081837-802a404223c
       compare-versions:
         specifier: ^6.1.1
         version: 6.1.1
@@ -452,8 +452,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@podman-desktop/api@1.17.2':
-    resolution: {integrity: sha512-tk4yEuZkNdVQ3NOqGQ8eDMduG/mR3ZUQmlAZbUbi+s839jqpSdzchTM9brj1LQmWSkJdnyP1Yp0q4u2jJsD4ew==}
+  '@podman-desktop/api@1.18.0-202504081837-802a404223c':
+    resolution: {integrity: sha512-PoVIcLyXa0UwGZK654ECF+Y3HoNUp07EXckxiJdE4jaFcDVviFQT8StpucBGGAw3BFDQ4NbGb1VeVd336gcWvg==}
 
   '@rollup/rollup-android-arm-eabi@4.39.0':
     resolution: {integrity: sha512-lGVys55Qb00Wvh8DMAocp5kIcaNzEFTmGhfFd88LfaogYTRKrdxgtlO5H6S49v2Nd8R2C6wLOal0qv6/kCkOwA==}
@@ -2275,9 +2275,6 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
-  std-env@3.9.0:
-    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
-
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -2952,7 +2949,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@podman-desktop/api@1.17.2': {}
+  '@podman-desktop/api@1.18.0-202504081837-802a404223c': {}
 
   '@rollup/rollup-android-arm-eabi@4.39.0':
     optional: true
@@ -4290,8 +4287,6 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  html-escaper@2.0.2: {}
-
   http-cache-semantics@4.1.1: {}
 
   http-proxy-agent@7.0.2:
@@ -5060,8 +5055,6 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
-
-  std-env@3.9.0: {}
 
   std-env@3.9.0: {}
 


### PR DESCRIPTION
This PR updates package.json file with a newer version Podman Desktop API for https://github.com/redhat-developer/podman-desktop-rhel-ext/issues/7,