### PR TITLE
chore: add .npmrc to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 **/coverage
 .idea
 .vscode
+/.npmrc


### PR DESCRIPTION
As credentials need to be added to the .npmrc file to pull the macadam.js file from GitHub registry, this helps not push the credential to the git repository