### PR TITLE
chore(test): adding test framework to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist
 .idea
 .vscode
 /.npmrc
+output
+test-results

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,7 +41,7 @@ const compat = new FlatCompat({
 });
 
 const TYPESCRIPT_PROJECTS = [
-  './tsconfig.json',
+  './tsconfig.json', 'tests/*/tsconfig.json',
 ];
 
 export default [

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -15,7 +15,6 @@
       "@types/node": "^22",
       "electron": "^35.2.0",
       "typescript": "^5.8.3",
-      "vitest": "^3.1.2",
       "xvfb-maybe": "^0.2.1"
     }
   }

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "rhel-extension-tests-playwright",
+    "version": "0.0.1",
+    "description": "Podman Desktop RHEL extension Playwright E2E tests",
+    "type": "module",
+    "scripts": {
+      "test:e2e:setup": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' --",
+      "test:e2e": "npm run test:e2e:setup npx playwright test src/"
+    },
+    "author": "Red Hat",
+    "license": "Apache-2.0",
+    "devDependencies": {
+      "@playwright/test": "1.52.0",
+      "@podman-desktop/tests-playwright": "1.18.0",
+      "@types/node": "^22",
+      "electron": "^35.2.0",
+      "typescript": "^5.8.3",
+      "vitest": "^3.1.2",
+      "xvfb-maybe": "^0.2.1"
+    }
+  }

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  outputDir: './output/',
+  workers: 1,
+
+  reporter: [
+    ['list'],
+    ['junit', { outputFile: './tests/output/junit-results.xml' }],
+    ['json', { outputFile: './tests/output/json-results.json' }],
+    ['html', { open: 'never', outputFolder: './tests/output/html-results/' }],
+  ],
+
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+  ],
+});

--- a/tests/playwright/tsconfig.json
+++ b/tests/playwright/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+      "target": "esnext",
+      "module": "esnext",
+      "moduleResolution": "node",
+      "strict": true,
+      "preserveValueImports": false,
+      "skipLibCheck": false,
+      "baseUrl": "."
+    },
+    "include": ["src/**/*.ts", "playwright.config.ts"],
+    "exclude": ["node_modules"]
+  }
+  


### PR DESCRIPTION
This PR adds the PD test framework to the repo in order to be used for test developement.

https://github.com/redhat-developer/podman-desktop-rhel-ext/issues/52