### PR TITLE
feat: use macadam.js version installing/using binaries in /opt/macadam/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,24 @@
 # Macadam Extension
 
-The Macadam extension is a POC to show how macadam tool can be used to init/start/stop any linux image (e.g fedora, rhel) in any OS
+The RHEL extension helps the user run RHEL VMs.
 
 ## Pre-requisites
 
-- Build macadam binary from sources (https://github.com/crc-org/macadam), and install it in the extension's directory `~/.local/share/containers/podman-desktop/extensions-storage/redhat.macadam/bin/` (keep the name as `macadam-${osName}-${arch}`).
-- Configure containers (`~/.config/containers/containers.conf`) to use default machine provider (not libkrun).
-- Install latest versions of `vfkit` (main branch) and `gvproxy` (v0.8.4) in a directory, and export the environment variable `CONTAINERS_HELPER_BINARY_DIR` with the name of the directory containing these executables.
+### On Windows
 
+The `macadam` binary is embedded in the extension, nothing needs to be installed.
+
+### On Mac
+
+When initialized, the extension checks if the necessary binaries are present in `/opt/macadam/bin`. If they are not, the extension installs them in this directory.
+
+> If this installation fails, you can run the installer manually, using the installer found at https://github.com/crc-org/macadam/releases/tag/v0.1.0. After this, you need to restart the extension which should find and use the binaries.
+
+## Install the extension
+
+OCI Images to install the extensions are available at https://github.com/redhat-developer/podman-desktop-rhel-ext/pkgs/container/podman-desktop-rhel-ext.
+
+The latest development image is ghcr.io/redhat-developer/podman-desktop-rhel-ext:next
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "watch": "vite build -w"
   },
   "dependencies": {
-    "@crc-org/macadam.js": "0.0.1-202504180956-af4279b",
+    "@crc-org/macadam.js": "0.0.1-202504281252-d8f4ce7",
     "@podman-desktop/api": "1.18.0",
     "compare-versions": "^6.1.1",
     "semver": "^7.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@crc-org/macadam.js':
-        specifier: 0.0.1-202504180956-af4279b
-        version: 0.0.1-202504180956-af4279b
+        specifier: 0.0.1-202504281252-d8f4ce7
+        version: 0.0.1-202504281252-d8f4ce7
       '@podman-desktop/api':
         specifier: 1.18.0
         version: 1.18.0
@@ -137,8 +137,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@crc-org/macadam.js@0.0.1-202504180956-af4279b':
-    resolution: {integrity: sha512-OHYeg5048jfNcCVbRChTwrsaelQDAMLwBPQXTaHGCd/S4KqT9jyQO+RgiRTxIYSkvbWO7pfMFtDHVM1hRcpUHw==, tarball: https://npm.pkg.github.com/download/@crc-org/macadam.js/0.0.1-202504180956-af4279b/ff3d88f8e021342f355b86f43b215ca9aa1686e8}
+  '@crc-org/macadam.js@0.0.1-202504281252-d8f4ce7':
+    resolution: {integrity: sha512-2G7ORfNZGGzgDO7gFWKiyi3c0Pc8667DfuwqygnfmhwfBgBHQ3cUf37FhdV8t7AZrgAKnLw5j4+69mbHUHrIEw==, tarball: https://npm.pkg.github.com/download/@crc-org/macadam.js/0.0.1-202504281252-d8f4ce7/57294911e841bd6057c2baca97c0a21fac4f604d}
 
   '@csstools/color-helpers@5.0.2':
     resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
@@ -2675,7 +2675,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@crc-org/macadam.js@0.0.1-202504180956-af4279b':
+  '@crc-org/macadam.js@0.0.1-202504281252-d8f4ce7':
     dependencies:
       '@podman-desktop/api': 1.18.0
 


### PR DESCRIPTION
At first install, the extension should install binaries in /opt/macadam/bin using the installer/

If it fails, the user can run the installer manually and restart the extension.

(installation from extension fails on my side when executed with `pnpm watch --extension-folder ...`, but works when installed from OCI image) 