### PR TITLE
chore: change location of gen files for Containerfile user permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ dist
 /.npmrc
 output
 test-results
-src/rh-api/gen
+src-gen

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,1 @@
-src/rh-api/gen/
+src-gen/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,7 +55,7 @@ export default [
       '**/coverage/',
       'extensions/*.ts',
       'scripts/**',
-      'src/rh-api/gen/*',
+      'src-gen/*',
     ],
   },
   js.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     }
   },
   "scripts": {
-    "generate:subscription-v1": "npx openapi-typescript src/rh-api/subscription-schema-v1.json -o src/rh-api/gen/subscription-v1.d.ts",
+    "generate:subscription-v1": "npx openapi-typescript src/rh-api/subscription-schema-v1.json -o src-gen/subscription-v1.d.ts",
     "build": "pnpm generate:subscription-v1 && vite build",
     "test": "vitest run --coverage --passWithNoTests",
     "test:watch": "vitest watch --coverage --passWithNoTests",

--- a/src/rh-api/rh-api-sm.ts
+++ b/src/rh-api/rh-api-sm.ts
@@ -20,7 +20,7 @@
 import type { Client } from 'openapi-fetch';
 import createClient from 'openapi-fetch';
 
-import type { paths } from './gen/subscription-v1';
+import type { paths } from '../../src-gen/subscription-v1';
 
 export const REGISTRY_REDHAT_IO = 'registry.redhat.io';
 


### PR DESCRIPTION
Following https://github.com/redhat-developer/podman-desktop-rhel-ext/pull/87, the build next workflow failed because the generated files were created in a location where the Containerfile's default user didn't have write permission. 
Moving them from `src/rh-api/gen/` to `src-gen` fixed the permissions issue.
Successful workflow: https://github.com/SoniaSandler/podman-desktop-rhel-ext/actions/runs/14801475840
Solution suggested in: https://github.com/redhat-developer/podman-desktop-rhel-ext/pull/87#pullrequestreview-2812339770