### PR TITLE
feat: make image download cancellable

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -493,7 +493,7 @@ async function createVM(
       const imageSha = getImageSha(provider);
       await mkdir(cachedImageDir, { recursive: true });
       logger?.log('Downloading image, please wait...\n');
-      await pullImageFromRedHatRegistry(client, imageSha, cachedImagePath);
+      await pullImageFromRedHatRegistry(client, imageSha, cachedImagePath, logger, token);
       logger?.log(`Image downloaded\n`);
       imagePath = cachedImagePath;
       telemetryRecords.imagePath = 'downloaded';


### PR DESCRIPTION
Fixes #109 

How to test:

- Remove cached image if it exists: `~/.local/share/containers/podman-desktop/extensions-storage/redhat.rhel-vms/images/image`
- Create a VM
- Wait for the file `~/.local/share/containers/podman-desktop/extensions-storage/redhat.rhel-vms/images/image` to be created
- Cancel, before the download is complete
- Check that "Download canceled" is displayed in the terminal
- Check that the file `~/.local/share/containers/podman-desktop/extensions-storage/redhat.rhel-vms/images/image` has been deleted