### PR TITLE
feat: add option to force download of image

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,13 @@
           "default": "RHEL 10",
           "description": "Image to download"
         },
+        "macadam.factory.machine.force-download": {
+          "type": "boolean",
+          "scope": "VmProviderConnectionFactory",
+          "default": false,
+          "description": "Force download image, do not get from cache",
+          "when": "!macadam.localImage"
+        },
         "macadam.factory.machine.image-path": {
           "type": "string",
           "format": "file",

--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -144,6 +144,20 @@ describe('activate', () => {
         expect(utils.pullImageFromRedHatRegistry).toHaveBeenCalled();
       });
 
+      test('RHEL image is pulled when download is forced, not considering if image is cached', async () => {
+        vi.mocked(ImageCache.prototype.getPath).mockReturnValue(
+          resolve('/', 'path', 'to', 'storage', 'images', 'rhel10'),
+        );
+        await create({
+          'macadam.factory.machine.image': 'RHEL 10',
+          'macadam.factory.machine.force-download': true,
+        });
+        // cache is not checked
+        expect(fs.existsSync).not.toHaveBeenCalled();
+        // image is pulled
+        expect(utils.pullImageFromRedHatRegistry).toHaveBeenCalled();
+      });
+
       test('RHEL image is not pulled when image is cached', async () => {
         vi.mocked(ImageCache.prototype.getPath).mockReturnValue(
           resolve('/', 'path', 'to', 'storage', 'images', 'rhel10'),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -496,9 +496,15 @@ async function createVM(
     telemetryRecords.imagePath = 'custom';
   }
 
+  // force-download
+  const forceDownload = params['macadam.factory.machine.force-download'] ?? false;
+  if (typeof forceDownload !== 'boolean') {
+    throw new Error('force-download must be a boolean');
+  }
+
   if (image) {
     const cachedImagePath = imageCache.getPath(image);
-    if (existsSync(cachedImagePath)) {
+    if (!forceDownload && existsSync(cachedImagePath)) {
       imagePath = cachedImagePath;
       telemetryRecords.imagePath = 'cached';
       logger?.log(`Using image cached in ${cachedImagePath}\n`);


### PR DESCRIPTION
Add option to force download of image

Fixes #106 

In VM creation form, when the user selects to download an image ("RHEL n" is selected), a checkbox is displayed, giving the choice to force the download of the image, even if the image is in the cache.
