### PR TITLE
fix: create cache directory earlier

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -34,8 +34,8 @@ export class ImageCache {
   }
 
   async init(): Promise<void> {
-    await this.cleanup();
     await mkdir(this.#cachedImageDir, { recursive: true });
+    await this.cleanup();
   }
 
   // delete all files not listed in cachedImageNames


### PR DESCRIPTION
Create cache directory earlier, to avoid errors opening the directory later

Fixes #169 