### PR TITLE
test: use memfs for unit tests

### DIFF
--- a/__mocks__/fs.cjs
+++ b/__mocks__/fs.cjs
@@ -1,0 +1,2 @@
+const { fs } = require('memfs')
+module.exports = fs

--- a/__mocks__/fs/promises.cjs
+++ b/__mocks__/fs/promises.cjs
@@ -1,0 +1,2 @@
+const { fs } = require('memfs')
+module.exports = fs.promises

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "eslint-plugin-sonarjs": "^3.0.3",
     "eslint-plugin-unicorn": "^59.0.1",
     "globals": "^16.2.0",
+    "memfs": "^4.17.2",
     "openapi-typescript": "^7.8.0",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       globals:
         specifier: ^16.2.0
         version: 16.2.0
+      memfs:
+        specifier: ^4.17.2
+        version: 4.17.2
       openapi-typescript:
         specifier: ^7.8.0
         version: 7.8.0(typescript@5.8.3)
@@ -434,6 +437,24 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@jsonjoy.com/base64@1.1.2':
+    resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/json-pack@1.2.0':
+    resolution: {integrity: sha512-io1zEbbYcElht3tdlqEOFxZ0dMTYrHz9iMf0gqn1pPjZFTCgM5R4R5IMA20Chb2UPYYsxjzs8CgZ7Nb5n2K2rA==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
+
+  '@jsonjoy.com/util@1.6.0':
+    resolution: {integrity: sha512-sw/RMbehRhN68WRtcKCpQOPfnH6lLP4GJfqzi3iYej8tnzpZUDr6UkZYJjcjjC0FWEJOJbyM3PTIwxucUmDG2A==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
 
   '@napi-rs/wasm-runtime@0.2.11':
     resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
@@ -1577,6 +1598,10 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  hyperdyperid@1.2.0:
+    resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
+    engines: {node: '>=10.18'}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -1839,6 +1864,10 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  memfs@4.17.2:
+    resolution: {integrity: sha512-NgYhCOWgovOXSzvYgUW0LQ7Qy72rWQMGGFJDoWg4G30RHd3z77VbYdtJ4fembJXBy8pMIUA31XNAupobOQlwdg==}
+    engines: {node: '>= 4.0.0'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2268,6 +2297,12 @@ packages:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
     engines: {node: '>=18'}
 
+  thingies@1.21.0:
+    resolution: {integrity: sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==}
+    engines: {node: '>=10.18'}
+    peerDependencies:
+      tslib: ^2
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -2308,6 +2343,12 @@ packages:
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
+
+  tree-dump@1.0.3:
+    resolution: {integrity: sha512-il+Cv80yVHFBwokQSfd4bldvr1Md951DpgAGfmhydt04L+YzHgubm2tQ7zueWDcGENKHq0ZvGFR/hjvNXilHEg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      tslib: '2'
 
   ts-api-utils@1.4.3:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
@@ -2838,6 +2879,22 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
+
+  '@jsonjoy.com/json-pack@1.2.0(tslib@2.8.1)':
+    dependencies:
+      '@jsonjoy.com/base64': 1.1.2(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.6.0(tslib@2.8.1)
+      hyperdyperid: 1.2.0
+      thingies: 1.21.0(tslib@2.8.1)
+      tslib: 2.8.1
+
+  '@jsonjoy.com/util@1.6.0(tslib@2.8.1)':
+    dependencies:
+      tslib: 2.8.1
 
   '@napi-rs/wasm-runtime@0.2.11':
     dependencies:
@@ -4242,6 +4299,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hyperdyperid@1.2.0: {}
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -4519,6 +4578,13 @@ snapshots:
       semver: 7.7.2
 
   math-intrinsics@1.1.0: {}
+
+  memfs@4.17.2:
+    dependencies:
+      '@jsonjoy.com/json-pack': 1.2.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.6.0(tslib@2.8.1)
+      tree-dump: 1.0.3(tslib@2.8.1)
+      tslib: 2.8.1
 
   merge2@1.4.1: {}
 
@@ -4982,6 +5048,10 @@ snapshots:
       glob: 10.4.5
       minimatch: 9.0.5
 
+  thingies@1.21.0(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -5018,6 +5088,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
     optional: true
+
+  tree-dump@1.0.3(tslib@2.8.1):
+    dependencies:
+      tslib: 2.8.1
 
   ts-api-utils@1.4.3(typescript@5.8.3):
     dependencies:

--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -15,12 +15,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-
-import * as fs from 'node:fs';
 import { resolve } from 'node:path';
 
 import * as macadamJSPackage from '@crc-org/macadam.js';
 import * as extensionApi from '@podman-desktop/api';
+import { vol } from 'memfs';
 import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import * as authentication from './authentication';
@@ -58,6 +57,7 @@ vi.mock('./macadam-machine-stream.js', async () => {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vol.reset();
 });
 
 describe('activate', () => {
@@ -135,12 +135,9 @@ describe('activate', () => {
         vi.mocked(ImageCache.prototype.getPath).mockReturnValue(
           resolve('/', 'path', 'to', 'storage', 'images', 'rhel10'),
         );
-        vi.mocked(fs.existsSync).mockReturnValue(false);
         await create({
           'rhel-vms.factory.machine.image': 'RHEL 10',
         });
-        expect(fs.existsSync).toHaveBeenCalledTimes(1);
-        expect(fs.existsSync).toHaveBeenCalledWith(resolve('/', 'path', 'to', 'storage', 'images', 'rhel10'));
         expect(utils.pullImageFromRedHatRegistry).toHaveBeenCalled();
       });
 
@@ -152,8 +149,9 @@ describe('activate', () => {
           'rhel-vms.factory.machine.image': 'RHEL 10',
           'rhel-vms.factory.machine.force-download': true,
         });
-        // cache is not checked
-        expect(fs.existsSync).not.toHaveBeenCalled();
+        vol.fromJSON({
+          '/path/to/storage/images/rhel10': '',
+        });
         // image is pulled
         expect(utils.pullImageFromRedHatRegistry).toHaveBeenCalled();
       });
@@ -162,12 +160,12 @@ describe('activate', () => {
         vi.mocked(ImageCache.prototype.getPath).mockReturnValue(
           resolve('/', 'path', 'to', 'storage', 'images', 'rhel10'),
         );
-        vi.mocked(fs.existsSync).mockReturnValue(true);
+        vol.fromJSON({
+          '/path/to/storage/images/rhel10': '',
+        });
         await create({
           'rhel-vms.factory.machine.image': 'RHEL 10',
         });
-        expect(fs.existsSync).toHaveBeenCalledTimes(1);
-        expect(fs.existsSync).toHaveBeenCalledWith(resolve('/', 'path', 'to', 'storage', 'images', 'rhel10'));
         expect(utils.pullImageFromRedHatRegistry).not.toHaveBeenCalled();
       });
 
@@ -175,7 +173,6 @@ describe('activate', () => {
         vi.mocked(ImageCache.prototype.getPath).mockReturnValue(
           resolve('/', 'path', 'to', 'storage', 'images', 'rhel10'),
         );
-        vi.mocked(fs.existsSync).mockReturnValue(true);
         await create({
           'rhel-vms.factory.machine.name': 'name1',
           'rhel-vms.factory.machine.image': 'RHEL 10',
@@ -190,7 +187,6 @@ describe('activate', () => {
       });
 
       test('createVm is called with provided image path', async () => {
-        vi.mocked(fs.existsSync).mockReturnValue(true);
         await create({
           'rhel-vms.factory.machine.image': 'local image on disk',
           'rhel-vms.factory.machine.name': 'name1',
@@ -223,12 +219,9 @@ describe('activate', () => {
         vi.mocked(ImageCache.prototype.getPath).mockReturnValue(
           resolve('/', 'path', 'to', 'storage', 'images', 'rhel10'),
         );
-        vi.mocked(fs.existsSync).mockReturnValue(false);
         await create({
           'rhel-vms.factory.machine.image': 'RHEL 10',
         });
-        expect(fs.existsSync).toHaveBeenCalledTimes(1);
-        expect(fs.existsSync).toHaveBeenCalledWith(resolve('/', 'path', 'to', 'storage', 'images', 'rhel10'));
         expect(utils.pullImageFromRedHatRegistry).toHaveBeenCalled();
       });
 
@@ -236,12 +229,12 @@ describe('activate', () => {
         vi.mocked(ImageCache.prototype.getPath).mockReturnValue(
           resolve('/', 'path', 'to', 'storage', 'images', 'rhel10'),
         );
-        vi.mocked(fs.existsSync).mockReturnValue(true);
+        vol.fromJSON({
+          '/path/to/storage/images/rhel10': '',
+        });
         await create({
           'rhel-vms.factory.machine.image': 'RHEL 10',
         });
-        expect(fs.existsSync).toHaveBeenCalledTimes(1);
-        expect(fs.existsSync).toHaveBeenCalledWith(resolve('/', 'path', 'to', 'storage', 'images', 'rhel10'));
         expect(utils.pullImageFromRedHatRegistry).not.toHaveBeenCalled();
       });
 
@@ -249,7 +242,6 @@ describe('activate', () => {
         vi.mocked(ImageCache.prototype.getPath).mockReturnValue(
           resolve('/', 'path', 'to', 'storage', 'images', 'rhel10'),
         );
-        vi.mocked(fs.existsSync).mockReturnValue(true);
         await create({
           'rhel-vms.factory.machine.name': 'name1',
           'rhel-vms.factory.machine.image': 'RHEL 10',
@@ -264,7 +256,6 @@ describe('activate', () => {
       });
 
       test('createVm is called with provided image path', async () => {
-        vi.mocked(fs.existsSync).mockReturnValue(true);
         await create({
           'rhel-vms.factory.machine.image': 'local image on disk',
           'rhel-vms.factory.machine.name': 'name1',


### PR DESCRIPTION
Following our discussion during team meeting, here is an usage of the `memfs` library to mock FS during unit tests.

Two files are using memfs to mock fs, and another one (utils.spec.ts) prefers to mock individual calls.

Fixes #170