### PR TITLE
fix: change machine stream close function context

### DIFF
--- a/src/macadam-machine-stream.ts
+++ b/src/macadam-machine-stream.ts
@@ -106,7 +106,6 @@ export class ProviderConnectionShellAccessImpl implements ProviderConnectionShel
 
           stream
             .on('close', () => {
-              console.error('close');
               this.onEndEmit.fire();
               this.closeStream();
             })
@@ -132,7 +131,7 @@ export class ProviderConnectionShellAccessImpl implements ProviderConnectionShel
       onEnd: this.onEnd,
       write: this.write.bind(this),
       resize: this.resize.bind(this),
-      close: this.close,
+      close: this.close.bind(this),
     };
   }
 }


### PR DESCRIPTION
Without binding the `close` function to `this`, any calling for `close` will output an error saying that `this.closeStream()`(L#82) is not a function due to the different calling context of `close` 

Related to https://github.com/redhat-developer/podman-desktop-rhel-ext/issues/81