### PR TITLE
ci: fix builder image by adding tests packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ dist
 **/coverage
 .idea
 .vscode
-/.npmrc
 output
 test-results
 src-gen

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted

--- a/build/Containerfile.builder
+++ b/build/Containerfile.builder
@@ -23,6 +23,9 @@ USER default
 
 COPY package.json .
 COPY pnpm-lock.yaml .
+COPY pnpm-workspace.yaml .
+COPY tests/playwright/package.json tests/playwright/package.json
+COPY .npmrc .npmrc
 
 RUN npm i -g ssh2@1.16.0 && \
     npm install --global pnpm@10 && \


### PR DESCRIPTION
needed for #313 and another error hidden by #313, when building `build/Containerfile`:

```
 ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for '@playwright/test@1.56.1' in pnpm-lock.yaml

This issue is probably caused by a badly resolved merge conflict.
To fix the lockfile, run 'pnpm install --no-frozen-lockfile'.
Error: building at STEP "RUN pnpm --frozen-lockfile install &&     pnpm build": while running runtime: exit status 1

```