### PR TITLE
chore: remove ssh from image builder

### DIFF
--- a/build/Containerfile.builder
+++ b/build/Containerfile.builder
@@ -28,8 +28,7 @@ COPY pnpm-workspace.yaml .
 COPY tests/playwright/package.json tests/playwright/package.json
 COPY .npmrc .npmrc
 
-RUN npm i -g ssh2@1.16.0 && \
-    PNPM_VERSION=$(cat package.json | jq .packageManager | sed -E 's|.*pnpm@([0-9.]+).*|\1|') && \
+RUN PNPM_VERSION=$(cat package.json | jq .packageManager | sed -E 's|.*pnpm@([0-9.]+).*|\1|') && \
     echo Installing pnpm version ${PNPM_VERSION} && \
     npm install --global pnpm@${PNPM_VERSION} && \
     pnpm --frozen-lockfile install


### PR DESCRIPTION
The install of `ssh` comes from the PoC of RHEL extension, but it is not necessary