### PR TITLE
chore: bump macadam.js library

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "test:e2e": "cd tests/playwright && npm run test:e2e"
   },
   "dependencies": {
-    "@crc-org/macadam.js": "0.3.1",
+    "@crc-org/macadam.js": "0.4.0-next.202601130801-a74070c",
     "@podman-desktop/api": "1.24.2",
     "compare-versions": "^6.1.1",
     "openapi-fetch": "^0.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@crc-org/macadam.js':
-        specifier: 0.3.1
-        version: 0.3.1
+        specifier: 0.4.0-next.202601130801-a74070c
+        version: 0.4.0-next.202601130801-a74070c
       '@podman-desktop/api':
         specifier: 1.24.2
         version: 1.24.2
@@ -157,8 +157,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@crc-org/macadam.js@0.3.1':
-    resolution: {integrity: sha512-IiXKgIYI7L7egC63hiFaUoIaMvBdBOY3iZEXf1A6Hw9CqVq13BvFKGev5RcBC5cX6TFFkTFewRGyYsP9aZL9NA==}
+  '@crc-org/macadam.js@0.4.0-next.202601130801-a74070c':
+    resolution: {integrity: sha512-YNDUMP3NRAlhWdtYFav2czBgAu1iBXiATbw1/jS9H4u+QWXGlFwS5qKHQO5qdYS1481G/a0X7377WX+2+Wd+QA==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -2653,9 +2653,10 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@crc-org/macadam.js@0.3.1':
+  '@crc-org/macadam.js@0.4.0-next.202601130801-a74070c':
     dependencies:
       '@podman-desktop/api': 1.24.2
+      semver: 7.7.3
 
   '@csstools/color-helpers@5.1.0':
     optional: true

--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -78,7 +78,7 @@ describe.each([true, false])('activate when binaries availability is %s', binari
 
   beforeEach(async () => {
     vi.mocked(extensionApi.provider.createProvider).mockReturnValue(provider);
-    vi.mocked(macadamJSPackage.Macadam.prototype.areBinariesAvailable).mockReturnValue(binariesAvailable);
+    vi.mocked(macadamJSPackage.Macadam.prototype.areBinariesAvailable).mockResolvedValue(binariesAvailable);
   });
 
   test('macadam library is initialized only if binaries are available', async () => {
@@ -590,7 +590,7 @@ describe('register', () => {
     vi.mocked(extensionApi.env).isWindows = false;
     vi.mocked(authentication.initAuthentication).mockResolvedValue(authClient);
 
-    vi.mocked(macadamJSPackage.Macadam.prototype.areBinariesAvailable).mockReturnValue(true);
+    vi.mocked(macadamJSPackage.Macadam.prototype.areBinariesAvailable).mockResolvedValue(true);
 
     await activate(extensionContext);
     expect(provider.setVmProviderConnectionFactory).toHaveBeenCalledOnce();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -105,7 +105,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     });
   });
 
-  if (macadam.areBinariesAvailable()) {
+  if (await macadam.areBinariesAvailable()) {
     await macadamInitializer.init();
   }
 


### PR DESCRIPTION
Use version of macadam.js which upgrade macadam binaries on macOS
