### PR TITLE
chore: update to macadam.js v0.6.0 including the signed installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "build-image": "pnpm cleanup && podman build . -f build/Containerfile"
   },
   "dependencies": {
-    "@crc-org/macadam.js": "0.5.0",
+    "@crc-org/macadam.js": "0.6.0",
     "@podman-desktop/api": "1.25.1",
     "compare-versions": "^6.1.1",
     "openapi-fetch": "^0.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@crc-org/macadam.js':
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.6.0
+        version: 0.6.0
       '@podman-desktop/api':
         specifier: 1.25.1
         version: 1.25.1
@@ -157,8 +157,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@crc-org/macadam.js@0.5.0':
-    resolution: {integrity: sha512-WBnReMQDkDJskNktER63+OYTBfWjdvT6+ZVUKdqRbUZrFqHjUPjtyEdrdc0yUV5JsqtUyQMMRuKhisiODO3x/g==}
+  '@crc-org/macadam.js@0.6.0':
+    resolution: {integrity: sha512-Gkj5JBQ18MG8Mp6Bl8pgkjjLjQh+D602/+RTJgl/+PmIXqhnY5Moy917iFnm8mcfhjMe7MuWcOT2TFYHJc62dA==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -2742,7 +2742,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@crc-org/macadam.js@0.5.0':
+  '@crc-org/macadam.js@0.6.0':
     dependencies:
       '@podman-desktop/api': 1.25.1
       semver: 7.7.3


### PR DESCRIPTION
for now the installer is not signed leading signing issues when trying to embed this extension

a new version of the JS wrapper library has been released including this signed installer (v0.6.0)


you can check before/after that now it's signed and before it isn't

```
pkgutil --check-signature node_modules/@crc-org/macadam.js/binaries/macadam-installer-macos-universal.pkg                                                                                  Package "macadam-installer-macos-universal.pkg":
   Status: signed by a developer certificate issued by Apple for distribution
   Notarization: trusted by the Apple notary service
....
```

fixes https://github.com/redhat-developer/podman-desktop-rhel-ext/issues/454