### PR TITLE
fix(ci): update Podman download URLs

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -145,7 +145,7 @@ jobs:
       - name: Execute pnpm in Red Hat RHEL VM Extension
         working-directory: ${{ env.REPOSITORY }}
         run: |
-          # workaround for https://github.com/containers/podman-desktop-extension-bootc/issues/712
+          # workaround for https://github.com/podman-desktop/podman-desktop-extension-bootc/issues/712
           version=$(npm view @podman-desktop/tests-playwright@next version)
           echo "Version of @podman-desktop/tests-playwright to be used: $version"
           jq --arg version "$version" '.devDependencies."@podman-desktop/tests-playwright" = $version' package.json > package.json_tmp && mv package.json_tmp package.json

--- a/.github/workflows/rhel-e2e-nightly-windows.yaml
+++ b/.github/workflows/rhel-e2e-nightly-windows.yaml
@@ -92,7 +92,7 @@ jobs:
     steps:
       - name: Get Podman version used by Desktop
         run: |
-          version=$(curl https://raw.githubusercontent.com/containers/podman-desktop/main/extensions/podman/packages/extension/src/podman5.json | jq -r '.version')
+          version=$(curl https://raw.githubusercontent.com/podman-desktop/podman-desktop/main/extensions/podman/packages/extension/src/podman5.json | jq -r '.version')
           echo "Default Podman Version from Podman Desktop: ${version}"
           echo "PD_PODMAN_VERSION=${version}" >> $GITHUB_ENV
       - name: Set the default env. variables

--- a/.github/workflows/rhel-e2e-nightly-windows.yaml
+++ b/.github/workflows/rhel-e2e-nightly-windows.yaml
@@ -43,7 +43,7 @@ on:
         type: string
         required: true
       podman_remote_url:
-        default: 'https://github.com/containers/podman/releases/download/v5.6.1/podman-5.6.1-setup.exe'
+        default: 'https://github.com/podman-container-tools/podman/releases/download/v5.6.1/podman-5.6.1-setup.exe'
         description: 'podman remote setup exe'
         type: string
         required: true
@@ -105,7 +105,7 @@ jobs:
           DEFAULT_EXT_TESTS_OPTIONS: 'EXT_RUN_TESTS_FROM_EXTENSION=1,EXT_RUN_TESTS_AS_ADMIN=0'
           DEFAULT_EXT_REPO_OPTIONS: 'REPO=podman-desktop-rhel-ext,FORK=redhat-developer,BRANCH=main'
           DEFAULT_PODMAN_VERSION: "${{ env.PD_PODMAN_VERSION || '5.6.1' }}"
-          DEFAULT_URL: 'https://github.com/containers/podman/releases/download/v$DEFAULT_PODMAN_VERSION/podman-$DEFAULT_PODMAN_VERSION-setup.exe'
+          DEFAULT_URL: 'https://github.com/podman-container-tools/podman/releases/download/v$DEFAULT_PODMAN_VERSION/podman-$DEFAULT_PODMAN_VERSION-setup.exe'
           DEFAULT_PDE2E_IMAGE_VERSION: 'v0.0.3'
           DEFAULT_MAPT_PARAMS: 'IMAGE=${{ vars.MAPT_IMAGE || ''quay.io/redhat-developer/mapt'' }};VERSION_TAG=${{ vars.MAPT_VERSION_TAG || ''v0.12.1'' }};CPUS=${{ vars.MAPT_CPUS || ''8  '' }};MEMORY=${{ vars.MAPT_MEMORY || ''32'' }};EXCLUDED_REGIONS="${{ vars.MAPT_EXCLUDED_REGIONS || ''westindia,centralindia,southindia,australiacentral,australiacentral2,australiaeast,australiasoutheast,southafricanorth,southafricawest'' }}"'
         run: |

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ You can use pnpm watch --extension-folder from the Podman Desktop directory to a
 Note: make sure you have the appropriate [pre-requisites](https://github.com/podman-desktop/podman-desktop/blob/main/CONTRIBUTING.md#prerequisites-prepare-your-environment) installed.
 
 ```
-git clone https://github.com/containers/podman-desktop
+git clone https://github.com/podman-desktop/podman-desktop
 git clone https://github.com/redhat-developer/podman-desktop-rhel-ext
 cd podman-desktop-rhel-ext
 pnpm install


### PR DESCRIPTION
## Summary
- update default `podman_remote_url` in nightly Windows workflow to `podman-container-tools/podman`
- update fallback `DEFAULT_URL` in workflow defaults to the new Podman org

Ref https://github.com/containers/podman-desktop-internal/issues/983

## Test plan
- [ ] Trigger `.github/workflows/rhel-e2e-nightly-windows.yaml` with defaults and confirm installer URL resolves

Made with [Cursor](https://cursor.com)