### PR TITLE
chore: add VmProviderConnection error property

### DIFF
--- a/src/extension.spec.ts
+++ b/src/extension.spec.ts
@@ -403,8 +403,18 @@ bla bla
         expect(provider.updateStatus).toHaveBeenCalledWith('ready');
       });
 
+      test('connection is initialized with error property set to undefined', async () => {
+        await activate(extensionContext);
+        await vi.waitFor(() => {
+          expect(provider.registerVmProviderConnection).toHaveBeenCalledOnce();
+        });
+        const call = vi.mocked(provider.registerVmProviderConnection).mock.calls[0];
+        expect(call[0].error).toBeUndefined();
+      });
+
       describe('start', async () => {
         let lifecycle: extensionApi.ProviderConnectionLifecycle;
+        let vmProviderConnection: extensionApi.VmProviderConnection;
         beforeEach(async () => {
           vi.mocked(provider.updateStatus).mockClear();
           await activate(extensionContext);
@@ -415,6 +425,7 @@ bla bla
           const call = vi.mocked(provider.registerVmProviderConnection).mock.calls[0];
           assert(!!call[0].lifecycle);
           lifecycle = call[0].lifecycle;
+          vmProviderConnection = call[0];
         });
 
         test('calling start which fails', async () => {
@@ -426,6 +437,7 @@ bla bla
               log: logger,
             }),
           ).rejects.toThrowError('an error');
+          expect(vmProviderConnection.error).toBe('an error');
         });
 
         describe('calling start which works correctly', async () => {
@@ -448,6 +460,7 @@ bla bla
               },
             });
             expect(provider.updateStatus).toHaveBeenCalledWith('started');
+            expect(vmProviderConnection.error).toBeUndefined();
           });
 
           test('calling stop which fails', async () => {
@@ -459,6 +472,7 @@ bla bla
                 log: logger,
               }),
             ).rejects.toThrowError('an error');
+            expect(vmProviderConnection.error).toBe('an error');
           });
 
           describe('calling stop which works correctly', async () => {
@@ -481,12 +495,14 @@ bla bla
                 },
               });
               expect(provider.updateStatus).toHaveBeenCalledWith('stopped');
+              expect(vmProviderConnection.error).toBeUndefined();
             });
 
             test('calling delete which fails', async () => {
               vi.mocked(macadamJSPackage.Macadam.prototype.removeVm).mockRejectedValue('an error');
               assert(!!lifecycle.delete);
               await expect(lifecycle.delete()).rejects.toThrowError('an error');
+              expect(vmProviderConnection.error).toBe('an error');
             });
 
             describe('calling delete which works correctly', async () => {
@@ -501,6 +517,7 @@ bla bla
                   name: 'vm1',
                   runOptions: {},
                 });
+                expect(vmProviderConnection.error).toBeUndefined();
               });
             });
           });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -256,18 +256,39 @@ async function registerProviderFor(
 ): Promise<void> {
   const lifecycle: extensionApi.ProviderConnectionLifecycle = {
     start: async (context, logger): Promise<void> => {
-      await startMachine(provider, machineInfo, context, logger);
+      try {
+        await startMachine(provider, machineInfo, context, logger);
+        vmProviderConnection.error = undefined;
+      } catch (err) {
+        vmProviderConnection.error = err instanceof Error ? err.message : String(err);
+        console.error(err);
+        throw err;
+      }
     },
     stop: async (context, logger): Promise<void> => {
-      await stopMachine(provider, machineInfo, context, logger);
+      try {
+        await stopMachine(provider, machineInfo, context, logger);
+        vmProviderConnection.error = undefined;
+      } catch (err) {
+        vmProviderConnection.error = err instanceof Error ? err.message : String(err);
+        console.error(err);
+        throw err;
+      }
     },
     delete: async (logger): Promise<void> => {
-      await macadamInitializer.ensureBinariesUpToDate();
-      await macadam.removeVm({
-        name: machineInfo.name,
-        containerProvider: verifyContainerProivder(machineInfo.vmType),
-        runOptions: { logger },
-      });
+      try {
+        await macadamInitializer.ensureBinariesUpToDate();
+        await macadam.removeVm({
+          name: machineInfo.name,
+          containerProvider: verifyContainerProivder(machineInfo.vmType),
+          runOptions: { logger },
+        });
+        vmProviderConnection.error = undefined;
+      } catch (err) {
+        vmProviderConnection.error = err instanceof Error ? err.message : String(err);
+        console.error(err);
+        throw err;
+      }
     },
   };
 
@@ -279,6 +300,7 @@ async function registerProviderFor(
     status: () => macadamMachinesStatuses.get(machineInfo.image) ?? 'unknown',
     shellAccess: providerConnectionShellAccess,
     lifecycle,
+    error: undefined,
   };
 
   const disposable = provider.registerVmProviderConnection(vmProviderConnection);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -256,6 +256,7 @@ async function registerProviderFor(
 ): Promise<void> {
   const lifecycle: extensionApi.ProviderConnectionLifecycle = {
     start: async (context, logger): Promise<void> => {
+      vmProviderConnection.error = undefined;
       try {
         await startMachine(provider, machineInfo, context, logger);
         vmProviderConnection.error = undefined;
@@ -266,6 +267,7 @@ async function registerProviderFor(
       }
     },
     stop: async (context, logger): Promise<void> => {
+      vmProviderConnection.error = undefined;
       try {
         await stopMachine(provider, machineInfo, context, logger);
         vmProviderConnection.error = undefined;
@@ -276,6 +278,7 @@ async function registerProviderFor(
       }
     },
     delete: async (logger): Promise<void> => {
+      vmProviderConnection.error = undefined;
       try {
         await macadamInitializer.ensureBinariesUpToDate();
         await macadam.removeVm({


### PR DESCRIPTION
Adds support for the `error` property of `VmProviderConnection` in the lifecycle methods

Closes https://github.com/redhat-developer/podman-desktop-rhel-ext/issues/528