### PR TITLE
chore(build): migrate from pnpm v10 to v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-node-linker=hoisted

--- a/build/Containerfile
+++ b/build/Containerfile
@@ -19,7 +19,7 @@ FROM ghcr.io/redhat-developer/podman-desktop-rhel-ext-builder:next AS builder
 
 COPY . .
 
-RUN pnpm --frozen-lockfile install && \
+RUN CI=true pnpm --frozen-lockfile install && \
     pnpm build
 
 RUN eval 'dep_version() { pnpm list -P $1 --json --depth 0 |jq -r ".[0].dependencies.\"$1\".version"; };' && \

--- a/build/Containerfile.builder
+++ b/build/Containerfile.builder
@@ -18,16 +18,13 @@
 # v10.1-1766363988
 FROM registry.access.redhat.com/ubi10/nodejs-24@sha256:5a3cea874f0555bcde27d979bbc8a067f1d75b4b324ef3274112c8270e951f5b
 USER root
-RUN dnf install -y jq
+RUN dnf install -y jq && npm i -g corepack && corepack enable
 USER default
 
 COPY package.json .
 COPY pnpm-lock.yaml .
 COPY pnpm-workspace.yaml .
 COPY tests/playwright/package.json tests/playwright/package.json
-COPY .npmrc .npmrc
 
-RUN PNPM_VERSION=$(cat package.json | jq .packageManager | sed -E 's|.*pnpm@([0-9.]+).*|\1|') && \
-    echo Installing pnpm version ${PNPM_VERSION} && \
-    npm install --global pnpm@${PNPM_VERSION} && \
-    pnpm --frozen-lockfile install
+RUN corepack install && \
+    CI=true pnpm --frozen-lockfile install

--- a/package.json
+++ b/package.json
@@ -28,7 +28,11 @@
         },
         "rhel-vms.factory.machine.image": {
           "type": "string",
-          "enum": ["RHEL 10", "RHEL 9", "local image on disk"],
+          "enum": [
+            "RHEL 10",
+            "RHEL 9",
+            "local image on disk"
+          ],
           "scope": "VmProviderConnectionFactory",
           "default": "RHEL 10",
           "description": "Image to download"
@@ -149,15 +153,5 @@
     "vite": "^8.1.5",
     "vitest": "^4"
   },
-  "packageManager": "pnpm@10.20.0+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd",
-  "pnpm": {
-    "overrides": {
-      "minimatch@>=9.0.0 <9.0.6": "^9.0.6",
-      "esbuild@>=0.17.0 <0.28.1": ">=0.28.1",
-      "brace-expansion@<1.1.16": "^1.1.16",
-      "brace-expansion@>=2.0.0 <2.1.2": "^2.1.2",
-      "js-yaml@<4.3.0": "^4.3.0",
-      "fast-uri@>=3.0.0 <3.1.4": "^3.1.4"
-    }
-  }
+  "packageManager": "pnpm@11.16.0+sha512.b767e9a98fc87aec0f42daefcd0e84941c2cdb45d73c4e1e68860fb2bdfdbe032ab592105479e5e05c237f740c8a5ffdbbb52385797ddc2296745a1bbb883e8d"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,14 @@
 packages:
   - 'tests/*'
+overrides:
+  minimatch@>=9.0.0 <9.0.6: ^9.0.6
+  esbuild@>=0.17.0 <0.28.1: '>=0.28.1'
+  brace-expansion@<1.1.16: ^1.1.16
+  brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
+  js-yaml@<4.3.0: ^4.3.0
+  fast-uri@>=3.0.0 <3.1.4: ^3.1.4
+nodeLinker: hoisted
+allowBuilds:
+  cpu-features: true
+  ssh2: true
+  unrs-resolver: true


### PR DESCRIPTION
- Run pnpm-v10-to-v11 codemod: moves overrides and nodeLinker from package.json/npmrc to pnpm-workspace.yaml, deletes .npmrc
- Update packageManager to pnpm@11.16.0 with sha512 integrity hash
- Add allowBuilds for cpu-features, ssh2, unrs-resolver
- Containerfile.builder: install corepack via npm, use corepack install instead of direct pnpm global install, remove .npmrc COPY
- Containerfile: add CI=true to pnpm install to avoid TTY prompt