### PR TITLE
fix(lint): resolve new sonarjs 4.2.0 rule violations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -218,4 +218,13 @@ export default [
       'sonarjs/publicly-writable-directories': 'off',
     },
   },
+
+  {
+    files: ['tests/playwright/**'],
+
+    rules: {
+      'sonarjs/assertions-in-tests': 'off',
+      'sonarjs/no-skipped-tests': 'off',
+    },
+  },
 ];

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -40,7 +40,7 @@ test('verifyContainerProivder', () => {
   expect(verifyContainerProivder('wsl')).toBe('wsl');
   expect(verifyContainerProivder('applehv')).toBe('applehv');
   expect(verifyContainerProivder('hyperv')).toBe('hyperv');
-  expect(verifyContainerProivder('someOtherProvider')).toBe(undefined);
+  expect(verifyContainerProivder('someOtherProvider')).toBeUndefined();
 });
 
 test('pullImageFromRedHatRegistry', async () => {


### PR DESCRIPTION
Disable assertions-in-tests and no-skipped-tests for Playwright E2E tests, and use toBeUndefined() instead of toBe(undefined).