### PR TITLE
fix: resolve GHSA-5p4m-2wfm-xmqj in js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
       "brace-expansion@^1": "^1.1.17",
       "brace-expansion@^2": "^2.1.4",
       "brace-expansion@^5": "^5.0.9",
-      "js-yaml@<4.3.0": "^4.3.0",
+      "js-yaml@^4": ">=4.3.1 <5",
       "fast-uri@>=3.0.0 <3.1.4": "^3.1.4"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   brace-expansion@^1: ^1.1.17
   brace-expansion@^2: ^2.1.4
   brace-expansion@^5: ^5.0.9
-  js-yaml@<4.3.0: ^4.3.0
+  js-yaml@^4: '>=4.3.1 <5'
   fast-uri@>=3.0.0 <3.1.4: ^3.1.4
 
 importers:
@@ -1773,8 +1773,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@26.0.0:
@@ -2814,7 +2814,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3034,7 +3034,7 @@ snapshots:
       colorette: 1.4.0
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       js-levenshtein: 1.1.6
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 5.1.9
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
@@ -4460,7 +4460,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability GHSA-5p4m-2wfm-xmqj in `js-yaml`.

**Advisory**: JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported
**Vulnerable versions**: >=4.0.0 <4.3.1
**Patched versions**: >=4.3.1
**Advisory URL**: https://github.com/advisories/GHSA-5p4m-2wfm-xmqj

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-5p4m-2wfm-xmqj: _JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported_

### How to test this PR?

Run `pnpm audit` and verify GHSA-5p4m-2wfm-xmqj is no longer reported