### PR TITLE
chore(pnpm): bump to v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-node-linker=hoisted

--- a/build/Containerfile.builder
+++ b/build/Containerfile.builder
@@ -25,7 +25,6 @@ COPY package.json .
 COPY pnpm-lock.yaml .
 COPY pnpm-workspace.yaml .
 COPY tests/playwright/package.json tests/playwright/package.json
-COPY .npmrc .npmrc
 
 RUN PNPM_VERSION=$(cat package.json | jq .packageManager | sed -E 's|.*pnpm@([0-9.]+).*|\1|') && \
     echo Installing pnpm version ${PNPM_VERSION} && \

--- a/package.json
+++ b/package.json
@@ -28,7 +28,11 @@
         },
         "rhel-vms.factory.machine.image": {
           "type": "string",
-          "enum": ["RHEL 10", "RHEL 9", "local image on disk"],
+          "enum": [
+            "RHEL 10",
+            "RHEL 9",
+            "local image on disk"
+          ],
           "scope": "VmProviderConnectionFactory",
           "default": "RHEL 10",
           "description": "Image to download"
@@ -149,16 +153,5 @@
     "vite": "^8.2.1",
     "vitest": "^4"
   },
-  "packageManager": "pnpm@10.20.0+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd",
-  "pnpm": {
-    "overrides": {
-      "minimatch@>=9.0.0 <9.0.6": "^9.0.6",
-      "esbuild@>=0.17.0 <0.28.1": ">=0.28.1",
-      "brace-expansion@^1": "^1.1.17",
-      "brace-expansion@^2": "^2.1.4",
-      "brace-expansion@^5": "^5.0.9",
-      "js-yaml@<4.3.0": "^4.3.0",
-      "fast-uri@>=3.0.0 <3.1.4": "^3.1.4"
-    }
-  }
+  "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,18 @@
 packages:
   - 'tests/*'
+overrides:
+  minimatch@>=9.0.0 <9.0.6: ^9.0.6
+  esbuild@>=0.17.0 <0.28.1: '>=0.28.1'
+  brace-expansion@^1: ^1.1.17
+  brace-expansion@^2: ^2.1.4
+  brace-expansion@^5: ^5.0.9
+  js-yaml@<4.3.0: ^4.3.0
+  fast-uri@>=3.0.0 <3.1.4: ^3.1.4
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@podman-desktop/tests-playwright'
+nodeLinker: hoisted
+allowBuilds:
+  cpu-features: true
+  ssh2: true
+  unrs-resolver: true


### PR DESCRIPTION
### What does this PR do?

Bumping pnpm to v11. I ran the migration script provided `pnpx codemod run pnpm-v10-to-v11`[^1]

[^1]: https://pnpm.io/migration

### What issues does this PR fix or reference?

Same as https://github.com/podman-desktop/podman-desktop/issues/17794

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be :green_circle: 
